### PR TITLE
Corrected the rustup site url

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To report a bug or ask for features use [github issues][issues].
 
 If you need to install Rust (come on, you should have done that long time ago!), use [rustup][rustup].
 
-[rustup]: https://rustup.rs
+[rustup]: https://www.rustup.rs
 
 ### In your project
 


### PR DESCRIPTION
https://rustup.rs is unreachable in a browser