### PR TITLE
Create passing macros for slog-scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = ["crates/json", "crates/term", "crates/stdlog", "crates/syslog",
 [dev-dependencies]
 slog-json = { path = "crates/json", version = "1" }
 slog-term = { path = "crates/term", version = "1" }
+slog-scope = { path = "crates/scope", version = "0" }
 slog-stdlog = { path = "crates/stdlog", version = "1.0.0" }
 slog-syslog = { path = "crates/syslog", version = "1.0.0-alpha8" }
 slog-bunyan = { path = "crates/bunyan", version = "1" }

--- a/crates/scope/Cargo.toml
+++ b/crates/scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-scope"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Logging scopes for slog-rs"
 keywords = ["slog", "logging", "slog", "log"]

--- a/crates/scope/lib.rs
+++ b/crates/scope/lib.rs
@@ -31,7 +31,7 @@
 
 #![warn(missing_docs)]
 
-#[macro_use]
+#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 #[macro_use]
 extern crate lazy_static;
@@ -42,6 +42,12 @@ use slog::*;
 use std::sync::Arc;
 use std::cell::RefCell;
 use crossbeam::sync::ArcCell;
+
+#[macro_export] macro_rules! trace( ($($args:tt)+) => { slog_trace![$crate::logger(), $($args)+]; };);
+#[macro_export] macro_rules! debug( ($($args:tt)+) => { slog_debug![$crate::logger(), $($args)+]; };);
+#[macro_export] macro_rules! info( ($($args:tt)+) => { slog_info![$crate::logger(), $($args)+]; };);
+#[macro_export] macro_rules! warn( ($($args:tt)+) => { slog_warn![$crate::logger(), $($args)+]; };);
+#[macro_export] macro_rules! error( ($($args:tt)+) => { slog_error![$crate::logger(), $($args)+]; };);
 
 thread_local! {
     static TL_SCOPES: RefCell<Vec<slog::Logger>> = RefCell::new(Vec::with_capacity(8))

--- a/examples/scope.rs
+++ b/examples/scope.rs
@@ -1,0 +1,20 @@
+#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
+extern crate slog;
+#[macro_use]
+extern crate slog_scope;
+extern crate slog_term;
+
+use slog::DrainExt;
+
+fn main() {
+	slog_scope::set_global_logger(slog::Logger::root(slog_term::streamer().build().fuse(), o![]));
+
+	info!["Info message using the global logger"];
+
+	slog_scope::scope(slog_scope::logger().new(o!["where" => "A RAII scope"]), || {
+		warn!["You are sending this to a composed logger"];
+		info!["You can also call any functions in this thread, and the logger will be passed via the thread-local"];
+	});
+
+	debug!["This is sent to the global logger, the scoped logger was popped"];
+}


### PR DESCRIPTION
This patch makes using slog-scope easier and more ergonomic:

	trace!["Current position"; "a" => 1, "b" => 2];

Will use the top logging context that is active. Logging contexts are
given as usual via `slog_scope::scope`.