### PR TITLE
Use global namespace for o! macro expansion for std

### DIFF
--- a/examples/signal.rs
+++ b/examples/signal.rs
@@ -12,6 +12,7 @@ extern crate lazy_static;
 use nix::sys::signal;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
+use std::time::Duration;
 
 use std::{thread, io};
 use slog::*;
@@ -64,6 +65,6 @@ fn main() {
     info!(log, "kill -SIGUSR1 {}", pid);
     loop {
         info!(log, "tick");
-        thread::sleep_ms(3000);
+        thread::sleep(Duration::from_millis(3000));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,7 @@ macro_rules! o(
     };
     ($($k:expr => $v:expr),*) => {
         {
-        use std;
-        vec![$(($k, std::boxed::Box::new($v))),*]
+        vec![$(($k, ::std::boxed::Box::new($v))),*]
         }
     };
     ($($k:expr => $v:expr),*,) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,3 +8,13 @@ fn logger_fmt_debug_sanity() {
 
     assert_eq!(format!("{:?}", log), "Logger(b, c, a)");
 }
+
+#[cfg(test)]
+mod tests {
+    use {Logger, Discard};
+    /// ensure o! macro expands without error inside a module
+    #[test]
+    fn test_o_macro_expansion() {
+        let _ = Logger::root(Discard, o!("a" => "aa"));
+    }
+}


### PR DESCRIPTION
Added a test case in a submodule as well for the `o!` macro; this test fails in `v1.0.0`.

Also added one commit to fix the deprecation notice for the signal example.