### PR TITLE
BREAKING: Rewrite handling of owned values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 (Unreleased)
+### Changed
+
+* BREAKING: Rewrite handling of owned values.
+
 ## 1.0.1
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Structured, composable logging for Rust"
 keywords = ["log", "logging", "structured", "hierarchical"]

--- a/benches/slog.rs
+++ b/benches/slog.rs
@@ -144,9 +144,9 @@ fn logger_new_nonempty_10(b: &mut Bencher) {
                 "u64" => 0u64,
                 "bool" => false,
                 "str" => "",
-                "f32" => 0f32, 
-                "f64" => 0f64, 
-                "option" => Some(0), 
+                "f32" => 0f32,
+                "f64" => 0f64,
+                "option" => Some(0),
                 "unit" => (),
                 ));
     });

--- a/benches/slog.rs
+++ b/benches/slog.rs
@@ -235,6 +235,46 @@ fn log_stream_json_blackbox_i32val(b: &mut Bencher) {
 }
 
 #[bench]
+fn log_stream_json_blackbox_10(b: &mut Bencher) {
+    let log = Logger::root(json_blackbox(), o!());
+
+    b.iter(|| {
+        info!(log, "";
+              "u8" => 0u8,
+              "u16" => 0u16,
+              "u32" => 0u32,
+              "u64" => 0u64,
+              "bool" => false,
+              "str" => "",
+              "f32" => 0f32,
+              "f64" => 0f64,
+              "option" => Some(0),
+              "unit" => (),
+              );
+    });
+}
+
+#[bench]
+fn log_stream_empty_json_blackbox_10(b: &mut Bencher) {
+    let log = Logger::root(empty_json_blackbox(), o!());
+
+    b.iter(|| {
+        info!(log, "";
+              "u8" => 0u8,
+              "u16" => 0u16,
+              "u32" => 0u32,
+              "u64" => 0u64,
+              "bool" => false,
+              "str" => "",
+              "f32" => 0f32,
+              "f64" => 0f64,
+              "option" => Some(0),
+              "unit" => (),
+              );
+    });
+}
+
+#[bench]
 fn log_stream_json_blackbox_i32closure(b: &mut Bencher) {
 
     let log = Logger::root(json_blackbox(), o!());
@@ -277,3 +317,26 @@ fn log_stream_json_blackbox_strpushclosure(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn tmp_file_write_1b(b: &mut Bencher) {
+    use std::io::Write;
+
+    let mut f = std::fs::OpenOptions::new().create(true).truncate(true).append(true).open("/tmp/slog-test-1b").unwrap();
+
+    b.iter(|| {
+        f.write_all(&[0]).unwrap();
+    });
+}
+
+
+#[bench]
+fn tmp_file_write_1kib(b: &mut Bencher) {
+    use std::io::Write;
+
+    let mut f = std::fs::OpenOptions::new().create(true).truncate(true).append(true).open("/tmp/slog-test-1k").unwrap();
+
+    let buf = vec!(0u8; 1024);
+    b.iter(|| {
+        f.write_all(&buf).unwrap();
+    });
+}

--- a/crates/bunyan/Cargo.toml
+++ b/crates/bunyan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-bunyan"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Bunyan formatter for slog-rs"
 keywords = ["log", "logging", "structured", "hierarchical"]
@@ -14,7 +14,7 @@ readme = "../../README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = { version = "1", path = "../.." }
+slog = { version = "1.1", path = "../.." }
 slog-json = { version = "1", path = "../json" }
 nix = "0.6.0"
 chrono = "0.2.22"

--- a/crates/bunyan/lib.rs
+++ b/crates/bunyan/lib.rs
@@ -110,7 +110,7 @@ mod test {
         };
 
         let mut v = vec![];
-        format.format(&mut v, &Record::new(&rs, format_args!("message"), &[]), &OwnedKeyValueList::root(vec![])).unwrap();
+        format.format(&mut v, &Record::new(&rs, format_args!("message"), &[]), &OwnedKeyValueList::root(None)).unwrap();
 
         assert_eq!(String::from_utf8_lossy(&v),
                    "{\"pid\":".to_string() + &nix::unistd::getpid().to_string() + ",\"host\":\"" +

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-json"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Json formatter for slog-rs"
 keywords = ["slog", "logging", "json"]
@@ -14,7 +14,7 @@ readme = "../../README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = { version = "1", path = "../.." }
+slog = { version = "1.1", path = "../.." }
 slog-serde = { version = "1.0.0-alpha8", path = "../serde"}
 slog-stream = { version = "1", path = "../stream" }
 serde_json = "0.8.2"

--- a/crates/stdlog/CHANGELOG.md
+++ b/crates/stdlog/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 (Unreleased)
+### Changed
+
+* BREAKING: Rewrite handling of owned values.
+
 ## 1.0.1 - 2016-10-02
 ### Changed
 

--- a/crates/stdlog/Cargo.toml
+++ b/crates/stdlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-stdlog"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Standard Rust log crate adapter to slog-rs"
 keywords = ["slog", "logging", "json", "log"]
@@ -14,7 +14,7 @@ readme = "../../README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = { version = "1", path = "../.." }
+slog = { version = "1.1", path = "../.." }
 slog-term = { version = "1", path = "../term" }
 log = "0.3.6"
 lazy_static = "0.2.1"

--- a/crates/stdlog/lib.rs
+++ b/crates/stdlog/lib.rs
@@ -274,7 +274,7 @@ impl<'a> fmt::Display for LazyLogString<'a> {
         let res = {
             || -> io::Result<()> {
 
-            for &(ref k, ref v) in self.logger_values.iter() {
+            for (ref k, ref v) in self.logger_values.iter() {
                 try!(ser.io().write_all(", ".as_bytes()));
                 try!(v.serialize(self.info, k, &mut ser));
             }

--- a/crates/syslog/Cargo.toml
+++ b/crates/syslog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-syslog"
-version = "1.0.0-alpha8"
+version = "1.0.0-alpha9"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]
@@ -14,7 +14,7 @@ readme = "../../README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = { version = "1", path = "../.." }
+slog = { version = "1.1", path = "../.." }
 slog-stream = { version = "1", path = "../stream" }
 syslog = "3.1.0"
 nix = "0.6.0"

--- a/crates/syslog/lib.rs
+++ b/crates/syslog/lib.rs
@@ -132,7 +132,7 @@ impl slog_stream::Format for Format3164 {
 
         let mut ser = KSV::new(io, ": ".into());
         {
-            for &(ref k, ref v) in logger_values.iter() {
+            for (ref k, ref v) in logger_values.iter() {
                 try!(ser.io().write_all(", ".as_bytes()));
                 try!(v.serialize(rinfo, k, &mut ser));
             }

--- a/crates/term/CHANGELOG.md
+++ b/crates/term/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.2.0 [Unreleased]
+### Changed
+
+* BREAKING: Rewrite handling of owned values.
+
 
 ## 1.1.0 - 2016-09-28
 ### Added

--- a/crates/term/Cargo.toml
+++ b/crates/term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-term"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Unix terminal drain and formatter for slog-rs"
 keywords = ["slog", "logging", "log", "term"]
@@ -14,7 +14,7 @@ readme = "../../README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = { version = "1", path = "../.." }
+slog = { version = "1.1", path = "../.." }
 slog-stream = { version = "1", path = "../stream" }
 isatty = "0.1"
 chrono = "0.2"


### PR DESCRIPTION
This saves a lot of allocations and improves creation time for loggers
with a lot of assigned key-values.

Instead of representing each `o!(...)` as

```
Vec<(&'static str, Box<Serialize>)>
```

it be represented as:

```
Box<(k1, v1, (k2, v2, (k3, v3, ...)))>
```

with a neat trait implementing operation on the whole chain.

Relevant benchmark goes from:

```
test logger_new_nonempty_10 ... bench: 206 ns/iter (+/- 5)
```

To:

```
test logger_new_nonempty_10 ... bench: 60 ns/iter (+/- 2)
```